### PR TITLE
Use UtcNow everywhere in middleware

### DIFF
--- a/RateLimitingDemo/CustomMiddleware/Middlewares/RateLimitingMiddleware.cs
+++ b/RateLimitingDemo/CustomMiddleware/Middlewares/RateLimitingMiddleware.cs
@@ -34,7 +34,7 @@ public class RateLimitingMiddleware
         // Check whether the request violates the rate limit policy
 
         if (_clientStatistics!=null
-            && DateTime.Now <_clientStatistics.LastSuccessfulResponseTime.AddSeconds(rateLimitDecorator.TimeWindow)
+            && DateTime.UtcNow <_clientStatistics.LastSuccessfulResponseTime.AddSeconds(rateLimitDecorator.TimeWindow)
             && _clientStatistics.NumberofRequestsCompletedSuccessfully ==rateLimitDecorator.MaxRequests)
         {
             context.Response.StatusCode = (int)HttpStatusCode.TooManyRequests;


### PR DESCRIPTION
The original code used DateTime.Now in one place and DateTime.UtcNow in other places. This makes the middleware work if the system happens to be running in a time zone where UtcNow and Now is the same but otherwise it will not work